### PR TITLE
IORQueryServant assignment operator implemented

### DIFF
--- a/TAF/MulticastDiscoveryUtility/MulticastDiscoveryUtility.cpp
+++ b/TAF/MulticastDiscoveryUtility/MulticastDiscoveryUtility.cpp
@@ -333,7 +333,7 @@ int main(int argc, char *argv[])
         const std::string mcast_address(DAF::get_property(TAF_DISCOVERYENDPOINT, TAF_DEFAULT_DISCOVERY_ENDPOINT, true));
 
 //        const ACE_INET_Addr MCAST_ADDRESS(Thestd::string
-        for (int z = 0; !shutdown_ ; z++) {
+        for (int z = 0; !shutdown_.has_shutdown() ; z++) {
 
             if (TAFDiscoveryHandler(ACE_INET_Addr(mcast_address.c_str())).sendIORQuery(replyHandler, taf::_tc_TAFServer->id()) == 0) {
 
@@ -343,7 +343,7 @@ int main(int argc, char *argv[])
 
                 if (ior_seq.size()) {
 
-                    if (shutdown_) {
+                    if (shutdown_.has_shutdown()) {
                         break;
                     }
 

--- a/TAF/taf/IORQueryServant.cpp
+++ b/TAF/taf/IORQueryServant.cpp
@@ -34,6 +34,17 @@ namespace TAF
     {
     }
 
+	IORQueryServant & 
+	IORQueryServant::operator = (const IORQueryServant &servant)
+	{
+		if (this != &servant)
+		{
+			IORServant_ref::operator=(servant);
+			ident_ = servant.ident_;
+			return *this;
+		}
+	}
+
     int
     IORQueryServant::is_ident(const std::string &ident) const
     {

--- a/TAF/taf/IORQueryServant.h
+++ b/TAF/taf/IORQueryServant.h
@@ -45,13 +45,14 @@ namespace TAF
         IORQueryServant(const IORQueryServant &); // Copy Constructor
         IORQueryServant(const CORBA::Object_ptr obj, const std::string &ident);
 
+		IORQueryServant& operator = (const IORQueryServant &);  // Assignment operator
         const std::string & ident(void) const { return this->ident_; }
 
         int is_ident(const std::string &ident) const;
 
     private:
 
-        const std::string ident_;
+        std::string ident_;
     };
 
     typedef class std::list<IORQueryServant>    IORQueryServantList;

--- a/daf/ShutdownHandler.h
+++ b/daf/ShutdownHandler.h
@@ -50,12 +50,6 @@ namespace DAF
         /// Send a shutdown state to the shutdown handler.
         static int  send_shutdown(bool send_state = true);
 
-        /// Accessor operator. give you current state
-        operator bool() const
-        {
-            return has_shutdown();
-        }
-
     protected:
         /// ACE_Reactor callback method on signal
         virtual int handle_signal(int sig, siginfo_t* sig_info, ucontext_t* sig_cxt);

--- a/daf/ShutdownHandler.h
+++ b/daf/ShutdownHandler.h
@@ -46,12 +46,12 @@ namespace DAF
         /// Indicates if the shutdown state has been signaled.
         static bool has_shutdown();
         /// Used by a thread to block on the shutdown signal.
-        static int  wait_shutdown(const ACE_Time_Value* abs_timeout = nullptr); // Absolute Time (nullptr => INFINITE)
+        static int  wait_shutdown(const ACE_Time_Value* abs_timeout = NULL); // Absolute Time (nullptr => INFINITE)
         /// Send a shutdown state to the shutdown handler.
         static int  send_shutdown(bool send_state = true);
 
         /// Accessor operator. give you current state
-        explicit operator bool() const
+        operator bool() const
         {
             return has_shutdown();
         }


### PR DESCRIPTION
IORQueryServant assignment operator was required due to the build errors using VS2019. The specific compile errors was related to std list and a deleted function being called.  